### PR TITLE
Correct formatting

### DIFF
--- a/FeaturesShim.md
+++ b/FeaturesShim.md
@@ -69,7 +69,7 @@ No, and this is another thing that sets it apart from symlinks. To create symlin
 Yes! When a shim detects that elevation is required, it will automatically request elevation.
 
 ### Why not simple batch redirection?
-We tried using batch ("*.bat") files, and it mostly works, but when applications calling other applications expect the file name to be ".exe", a file named "*.bat" doesn't work. Batch files also don't work in all shells, and shims do.
+We tried using batch ("\*.bat") files, and it mostly works, but when applications calling other applications expect the file name to be ".exe", a file named "\*.bat" doesn't work. Batch files also don't work in all shells, and shims do.
 
 ### Have you thought about shimming in more places?
 Yes, but we have not decided whether shimming Program Files is a good idea yet or not. Packages can explicitly enforce shims with [[Install-BinFile|HelpersInstallBinFile]].
@@ -78,16 +78,16 @@ Yes, but we have not decided whether shimming Program Files is a good idea yet o
 If you are creating a package and you need to shim a file that doesn't end in .exe (like a .bat file), you should look at [[Install-BinFile|HelpersInstallBinFile]].
 
 ### I need to exclude a file from shimming.
-If you are creating a package and you want to skip creation of a shim for a particular file, you can create a "*.ignore" file.
+If you are creating a package and you want to skip creation of a shim for a particular file, you can create a "\*.ignore" file.
 
 Set an empty file next to the executable (or where it will be downloaded/unpacked to), sharing the same name with the executable and appending ".ignore". For example, if your file is named "`bob.exe`", you need a file named "`bob.exe.ignore`" (pay attention to case - "`BOB.exe.ignore`" may not work with all versions of Chocolatey).
 
 [[Read more...|CreatePackages#how-do-i-exclude-executables-from-getting-shims]]
 
 ### How can I ensure a GUI shim?
-Chocolatey 0.9.10+ will automatically detect GUI applications and adjust the shim accordingly. The detection may not always be accurate, and older versions of Chocolatey don't handle this, so it's best to create a "*.gui" file to direct the shim creation to be for a GUI application.
+Chocolatey 0.9.10+ will automatically detect GUI applications and adjust the shim accordingly. The detection may not always be accurate, and older versions of Chocolatey don't handle this, so it's best to create a "\*.gui" file to direct the shim creation to be for a GUI application.
 
-If you are creating a package and want the shim to exit immediately after calling the application, create an empty "*.gui" file next to where the exe file is (or where it will be downloaded/unpacked to), sharing the same name with the executable and appending ".gui". For example, if your file is named "`bob.exe`", you need a file named "`bob.exe.gui`" (pay attention to case - "`BOB.exe.gui`" may not work with all versions of Chocolatey).
+If you are creating a package and want the shim to exit immediately after calling the application, create an empty "\*.gui" file next to where the exe file is (or where it will be downloaded/unpacked to), sharing the same name with the executable and appending ".gui". For example, if your file is named "`bob.exe`", you need a file named "`bob.exe.gui`" (pay attention to case - "`BOB.exe.gui`" may not work with all versions of Chocolatey).
 
 [[Read more...|CreatePackages#how-do-i-set-up-shims-for-applications-that-have-a-gui]]
 


### PR DESCRIPTION
This corrects the formatting for the asterisks in this file.

The asterisks weren't rendering on the website or markdown. This fixes them for the markdown - I assume the same will work for the website, but I'm not sure.

This also wasn't the issue I was intending to solve! Opened this file as there are broken characters by many of the quote marks on the website - although I can't see anything in the source that would cause that. Maybe those will go away when the site is rebuilt? 

https://chocolatey.org/docs/features-shim
![image](https://user-images.githubusercontent.com/4837132/27129712-2581bc4e-50fb-11e7-8bb0-13bde6d9d94c.png)
